### PR TITLE
fix: set cookie `SameSite` to `none`

### DIFF
--- a/apps/server/src/auth/auth.controller.ts
+++ b/apps/server/src/auth/auth.controller.ts
@@ -26,14 +26,14 @@ export class AuthController {
         res.cookie(Cookie.ACCESS, access_token, {
           httpOnly: true,
           maxAge: serverConfig.auth.cookieMaxAge[Cookie.ACCESS],
-          sameSite: 'none', // FIXME unsecure
+          sameSite: 'none', // FIXME unsecure, lax was not working, use another storage method than cookies? https://supabase.com/docs/guides/auth/sessions/pkce-flow#how-it-works
           secure: process.env.NODE_ENV === 'production',
         })
         res.cookie(Cookie.REFRESH, refresh_token, {
           httpOnly: true,
           maxAge: serverConfig.auth.cookieMaxAge[Cookie.REFRESH],
-          sameSite: 'none', // FIXME unsecure
           secure: process.env.NODE_ENV === 'production',
+          sameSite: 'none', // FIXME unsecure, lax was not working, use another storage method than cookies? https://supabase.com/docs/guides/auth/sessions/pkce-flow#how-it-works          secure: process.env.NODE_ENV === 'production',
         })
         res.redirect(`${serverConfig.clientUrl}/${serverConfig.auth.redirect}`)
       }


### PR DESCRIPTION
By setting `SameSite` atribute of the cookie, they aren't sent from the client to the server in the production environment.  
I am not sure why `lax` wasn't enough.
Temporarily switching to  the **unsecure** (CSRF attacks) `SameSite: "none"`.  

Maybe implement later (#35) a session storage adapter that does not rely on cookies. As suggested [here](https://supabase.com/docs/guides/auth/sessions/pkce-flow#how-it-works)
